### PR TITLE
Use data URL that always resolves to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You can copy the citations direction from these websites: 
 
-- Dataset: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888833.svg)](https://doi.org/10.5281/zenodo.10888833)
+- Dataset: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10888832.svg)](https://doi.org/10.5281/zenodo.10888832)
 - Pre-Print: [https://doi.org/10.31219/osf.io/q4fjy](https://doi.org/10.31219/osf.io/q4fjy)
 - Publication: *coming soon*
 


### PR DESCRIPTION
The README currently links to a particular release on Zenodo (https://zenodo.org/records/10888833). Zenodo provides another DOI and associated url (10.5281/zenodo.10888832, https://doi.org/10.5281/zenodo.10888832) that always resolves to the most recent release, whatever that is. The benefit of using this perpetually fresh URL on the main README is that you won't need to remember to update it every time you want to cut a new release with, for example, a bug fix.